### PR TITLE
TASK: code cleanup and set flow minimum requirement

### DIFF
--- a/Classes/Command/AssetCommandController.php
+++ b/Classes/Command/AssetCommandController.php
@@ -10,8 +10,7 @@ namespace PunktDe\AssetExport\Command;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
-use Neos\Flow\ResourceManagement\ResourceManager;
-use Neos\Flow\ResourceManagement\Storage\StorageObject;
+use Neos\Flow\Cli\Exception\StopCommandException;
 use Neos\Media\Domain\Model\Asset;
 use Neos\Media\Domain\Repository\AssetRepository;
 use Neos\Utility\Exception\FilesException;
@@ -22,20 +21,22 @@ class AssetCommandController extends CommandController
 
     /**
      * @Flow\Inject
-     * @var AssetRepository
      */
-    protected $assetRepository;
+    protected AssetRepository $assetRepository;
 
     /**
+     * Takes care of exporting all assets stored in Neos as files. This can be very helpful for backups.
+     *
      * @param string $targetPath The path where the resource files should be exported to.
      * @param bool $emptyTargetPath If set, all files in the target path will be deleted before the export runs
      * @throws FilesException
+     * @throws StopCommandException
      */
     public function exportCommand(string $targetPath, bool $emptyTargetPath = false): void
     {
         if (!is_dir($targetPath)) {
             $this->outputLine('The target path does not exist.');
-            exit(1);
+            $this->quit(1);
         }
 
         $targetPath = realpath($targetPath) . '/';

--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@ This package takes care of exporting all assets stored in Neos CMS as files. Thi
 
 ## Installation
 
-    $ composer require punktde/assetexport
+```bash
+composer require punktde/assetexport
+```
 
 ## Usage
 
-    $ ./flow asset:export my/export/path
+```bash
+./flow asset:export my/export/path
+```

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "name": "punktde/assetexport",
     "license": "MIT",
     "require": {
-        "neos/flow": "*"
+        "neos/flow": "^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
My pull request contains the following changes:

- Codeblocks in README
- Inline documentation for command when running: `./flow help asset:export`
- Drop the requirement for older Flow versions (4.0 and 5.0 and older) and set the minimum Flow requirement too 7.x and 8.x
- Code cleanup (eg. removing unused `use` imports)
- Command has also been tested with Neos 9 and works well.